### PR TITLE
Add more ignore and skip tests to the list

### DIFF
--- a/skipped_tests.toml
+++ b/skipped_tests.toml
@@ -55,9 +55,6 @@ unit = [
 	"tests/pytests/unit/modules/test_transactional_update.py::test_call_success_parameters",
 	"tests/pytests/unit/modules/test_transactional_update.py::test_call_success_reboot",
 	"tests/pytests/unit/states/file/test_tidied.py::test_tidied_age_size_args_AND_operator_age_not_size",
-	"tests/unit/modules/test_zcbuildout.py::BuildoutOnlineTestCase::test_buildout",  # Unmaintained test - skipped upstream
-	"tests/unit/modules/test_zcbuildout.py::BuildoutOnlineTestCase::test_run_buildout",  # Unmaintained test - skipped upstream
-	"tests/unit/states/test_zcbuildout.py::BuildoutTestCase::test_installed",  # Unmaintained test - skipped upstream
 	"tests/pytests/unit/states/file/test_tidied.py::test_tidied_age_size_args_AND_operator_size_not_age",
 	"tests/pytests/unit/states/test_pkgrepo.py::test_migrated_wrong_method",
 	"tests/pytests/unit/utils/test_gitfs.py::test_full_id_pygit2",
@@ -73,6 +70,8 @@ unit = [
 	"tests/unit/cli/test_support.py::ProfileIntegrityTestCase::test_non_template_profiles_parseable",
 	"tests/unit/cli/test_support.py::ProfileIntegrityTestCase::test_users_template_profile",
 	"tests/unit/modules/test_dpkg_lowpkg.py::DpkgTestCase::test_info",
+	"tests/unit/modules/test_zcbuildout.py::BuildoutOnlineTestCase::test_buildout",  # Unmaintained test - skipped upstream
+	"tests/unit/modules/test_zcbuildout.py::BuildoutOnlineTestCase::test_run_buildout",  # Unmaintained test - skipped upstream
 	"tests/unit/states/test_boto_apigateway.py::BotoApiGatewayTestCase::test_absent_when_failing_to_delete_a_deployment_no_longer_associated_with_any_stages",
 	"tests/unit/states/test_boto_apigateway.py::BotoApiGatewayTestCase::test_absent_when_nuke_api_and_no_more_stages_deployments_remain",
 	"tests/unit/states/test_boto_apigateway.py::BotoApiGatewayTestCase::test_absent_when_nuke_api_and_other_stages_deployments_exist",
@@ -107,6 +106,7 @@ unit = [
 	"tests/unit/states/test_boto_cognitoidentity.py::BotoCognitoIdentityTestCase::test_present_when_multiple_pools_with_same_name_exist",
 	"tests/unit/states/test_boto_cognitoidentity.py::BotoCognitoIdentityTestCase::test_present_when_pool_name_does_not_exist",  # missing boto libraries
 	"tests/unit/states/test_boto_cognitoidentity.py::BotoCognitoIdentityTestCase::test_present_when_pool_name_exists",  # missing boto libraries
+	"tests/unit/states/test_zcbuildout.py::BuildoutTestCase::test_installed",  # Unmaintained test - skipped upstream
 	"tests/unit/test_config.py::APIConfigTestCase::test_api_config_log_file_values",
 	"tests/unit/test_config.py::APIConfigTestCase::test_api_config_prepend_root_dirs_return",
 	"tests/unit/test_config.py::ConfigTestCase::test_load_minion_config_from_environ_var",
@@ -127,6 +127,7 @@ unit = [
 integration = [
 	"tests/integration/loader/test_ext_modules.py",  # Make pytest to stuck in sle15sp1 classic pkg
 	"tests/integration/modules/test_cmdmod.py::CMDModuleTest::test_which_bin",
+	"tests/integration/ssh/test_state.py::SSHStateTest::test_state_running",  # This test makes no sense with new locking mechanism for Salt SSH
 	"tests/pytests/integration/master/test_clear_funcs.py::test_clearfuncs_config",
 	"tests/pytests/integration/master/test_clear_funcs.py::test_fileroots_read",
 	"tests/pytests/integration/master/test_clear_funcs.py::test_fileroots_write",
@@ -136,7 +137,7 @@ integration = [
 	"tests/pytests/integration/runners/state/orchestrate/test_events.py::test_jid_in_ret_event",
 	"tests/pytests/integration/runners/state/orchestrate/test_events.py::test_orchestration_with_pillar_dot_items",
 	"tests/pytests/integration/runners/state/orchestrate/test_events.py::test_parallel_orchestrations",
-	"tests/integration/ssh/test_state.py::SSHStateTest::test_state_running",  # This test makes no sense with new locking mechanism for Salt SSH
+	"tests/pytests/integration/ssh/test_master.py::test_service",  # Failing when running on containers. dbus not available
 ]
 functional = [
 	"tests/pytests/functional/channel/test_server.py::test_pub_server_channel[transport(zeromq)]",

--- a/skipped_tests.toml
+++ b/skipped_tests.toml
@@ -70,43 +70,6 @@ unit = [
 	"tests/unit/cli/test_support.py::ProfileIntegrityTestCase::test_non_template_profiles_parseable",
 	"tests/unit/cli/test_support.py::ProfileIntegrityTestCase::test_users_template_profile",
 	"tests/unit/modules/test_dpkg_lowpkg.py::DpkgTestCase::test_info",
-	"tests/unit/modules/test_zcbuildout.py::BuildoutOnlineTestCase::test_buildout",  # Unmaintained test - skipped upstream
-	"tests/unit/modules/test_zcbuildout.py::BuildoutOnlineTestCase::test_run_buildout",  # Unmaintained test - skipped upstream
-	"tests/unit/states/test_boto_apigateway.py::BotoApiGatewayTestCase::test_absent_when_failing_to_delete_a_deployment_no_longer_associated_with_any_stages",
-	"tests/unit/states/test_boto_apigateway.py::BotoApiGatewayTestCase::test_absent_when_nuke_api_and_no_more_stages_deployments_remain",
-	"tests/unit/states/test_boto_apigateway.py::BotoApiGatewayTestCase::test_absent_when_nuke_api_and_other_stages_deployments_exist",
-	"tests/unit/states/test_boto_apigateway.py::BotoApiGatewayTestCase::test_absent_when_rest_api_does_not_exist",
-	"tests/unit/states/test_boto_apigateway.py::BotoApiGatewayTestCase::test_absent_when_stage_is_invalid",
-	"tests/unit/states/test_boto_apigateway.py::BotoApiGatewayTestCase::test_absent_when_stage_is_valid_and_only_one_stage_is_associated_to_deployment",
-	"tests/unit/states/test_boto_apigateway.py::BotoApiGatewayTestCase::test_absent_when_stage_is_valid_and_two_stages_are_associated_to_deployment",
-	"tests/unit/states/test_boto_apigateway.py::BotoApiGatewayTestCase::test_present_when_stage_associating_to_new_deployment_errored_on_api_creation",
-	"tests/unit/states/test_boto_apigateway.py::BotoApiGatewayTestCase::test_present_when_stage_associating_to_new_deployment_errored_on_lambda_function_lookup",  # missing boto libraries
-	"tests/unit/states/test_boto_apigateway.py::BotoApiGatewayTestCase::test_present_when_stage_associating_to_new_deployment_errored_on_model_creation",
-	"tests/unit/states/test_boto_apigateway.py::BotoApiGatewayTestCase::test_present_when_stage_associating_to_new_deployment_errored_on_put_integration",  # missing boto libraries
-	"tests/unit/states/test_boto_apigateway.py::BotoApiGatewayTestCase::test_present_when_stage_associating_to_new_deployment_errored_on_put_integration_response",  # missing boto libraries
-	"tests/unit/states/test_boto_apigateway.py::BotoApiGatewayTestCase::test_present_when_stage_associating_to_new_deployment_errored_on_put_method",  # missing boto libraries
-	"tests/unit/states/test_boto_apigateway.py::BotoApiGatewayTestCase::test_present_when_stage_associating_to_new_deployment_errored_on_put_method_response",  # missing boto libraries
-	"tests/unit/states/test_boto_apigateway.py::BotoApiGatewayTestCase::test_present_when_stage_associating_to_new_deployment_errored_on_resource_creation",
-	"tests/unit/states/test_boto_apigateway.py::BotoApiGatewayTestCase::test_present_when_stage_exists_and_is_to_associate_to_existing_deployment",
-	"tests/unit/states/test_boto_apigateway.py::BotoApiGatewayTestCase::test_present_when_stage_is_already_at_desired_deployment",
-	"tests/unit/states/test_boto_apigateway.py::BotoApiGatewayTestCase::test_present_when_stage_is_already_at_desired_deployment_and_needs_stage_variables_update",
-	"tests/unit/states/test_boto_apigateway.py::BotoApiGatewayTestCase::test_present_when_stage_is_to_associate_to_new_deployment",  # missing boto libraries
-	"tests/unit/states/test_boto_apigateway.py::BotoApiGatewayTestCase::test_present_when_swagger_file_is_invalid",
-	"tests/unit/states/test_boto_cognitoidentity.py::BotoCognitoIdentityTestCase::test_absent_when_a_single_pool_exists",
-	"tests/unit/states/test_boto_cognitoidentity.py::BotoCognitoIdentityTestCase::test_absent_when_erroring_on_delete_identity_pool",
-	"tests/unit/states/test_boto_cognitoidentity.py::BotoCognitoIdentityTestCase::test_absent_when_failing_to_describe_identity_pools",
-	"tests/unit/states/test_boto_cognitoidentity.py::BotoCognitoIdentityTestCase::test_absent_when_multiple_pool_exists_and_removeallmatched_flag_is_true",
-	"tests/unit/states/test_boto_cognitoidentity.py::BotoCognitoIdentityTestCase::test_absent_when_pool_does_not_exist",
-	"tests/unit/states/test_boto_cognitoidentity.py::BotoCognitoIdentityTestCase::test_absent_when_removeallmatched_is_false_and_multiple_pools_matched",
-	"tests/unit/states/test_boto_cognitoidentity.py::BotoCognitoIdentityTestCase::test_present_when_failing_to_create_a_new_identity_pool",
-	"tests/unit/states/test_boto_cognitoidentity.py::BotoCognitoIdentityTestCase::test_present_when_failing_to_describe_identity_pools",
-	"tests/unit/states/test_boto_cognitoidentity.py::BotoCognitoIdentityTestCase::test_present_when_failing_to_get_identity_pool_roles",
-	"tests/unit/states/test_boto_cognitoidentity.py::BotoCognitoIdentityTestCase::test_present_when_failing_to_set_identity_pool_roles",  # missing boto libraries
-	"tests/unit/states/test_boto_cognitoidentity.py::BotoCognitoIdentityTestCase::test_present_when_failing_to_update_an_existing_identity_pool",
-	"tests/unit/states/test_boto_cognitoidentity.py::BotoCognitoIdentityTestCase::test_present_when_multiple_pools_with_same_name_exist",
-	"tests/unit/states/test_boto_cognitoidentity.py::BotoCognitoIdentityTestCase::test_present_when_pool_name_does_not_exist",  # missing boto libraries
-	"tests/unit/states/test_boto_cognitoidentity.py::BotoCognitoIdentityTestCase::test_present_when_pool_name_exists",  # missing boto libraries
-	"tests/unit/states/test_zcbuildout.py::BuildoutTestCase::test_installed",  # Unmaintained test - skipped upstream
 	"tests/unit/test_config.py::APIConfigTestCase::test_api_config_log_file_values",
 	"tests/unit/test_config.py::APIConfigTestCase::test_api_config_prepend_root_dirs_return",
 	"tests/unit/test_config.py::ConfigTestCase::test_load_minion_config_from_environ_var",
@@ -127,7 +90,6 @@ unit = [
 integration = [
 	"tests/integration/loader/test_ext_modules.py",  # Make pytest to stuck in sle15sp1 classic pkg
 	"tests/integration/modules/test_cmdmod.py::CMDModuleTest::test_which_bin",
-	"tests/integration/ssh/test_state.py::SSHStateTest::test_state_running",  # This test makes no sense with new locking mechanism for Salt SSH
 	"tests/pytests/integration/master/test_clear_funcs.py::test_clearfuncs_config",
 	"tests/pytests/integration/master/test_clear_funcs.py::test_fileroots_read",
 	"tests/pytests/integration/master/test_clear_funcs.py::test_fileroots_write",
@@ -137,7 +99,6 @@ integration = [
 	"tests/pytests/integration/runners/state/orchestrate/test_events.py::test_jid_in_ret_event",
 	"tests/pytests/integration/runners/state/orchestrate/test_events.py::test_orchestration_with_pillar_dot_items",
 	"tests/pytests/integration/runners/state/orchestrate/test_events.py::test_parallel_orchestrations",
-	"tests/pytests/integration/ssh/test_master.py::test_service",  # Failing when running on containers. dbus not available
 ]
 functional = [
 	"tests/pytests/functional/channel/test_server.py::test_pub_server_channel[transport(zeromq)]",

--- a/skipped_tests.toml
+++ b/skipped_tests.toml
@@ -6,10 +6,6 @@ unit = [
 	"tests/unit/modules/test_boto_route53.py",
 	"tests/unit/states/test_module.py",
 	"tests/unit/utils/test_boto3mod.py",
-	"tests/unit/modules/test_boto3_elasticsearch.py",
-	"tests/unit/modules/test_boto3_route53.py",
-	"tests/unit/modules/test_boto_route53.py",
-	"tests/unit/utils/test_boto3mod.py",
 ]
 integration = [
 	"tests/pytests/integration/modules/test_x509_v2.py",
@@ -158,7 +154,7 @@ functional = [
 	"tests/pytests/functional/states/test_pip_state.py::test_pip_installed_name_test_mode",
 	"tests/pytests/functional/states/test_pip_state.py::test_pip_installed_pkgs_test_mode",
 	"tests/pytests/functional/transport/ipc/test_pub_server_channel.py::test_issue_36469_tcp",  # Make pytest to hang on sle15sp1
-	"tests/pytests/functional/transport/ipc/test_pub_server_channel.py::test_publish_to_pubserv_ipc",
+	"tests/pytests/functional/transport/ipc/test_pub_server_channel.py::test_publish_to_pubserv_ipc",  # Make pytest to hang during cleanup
 	"tests/pytests/functional/transport/tcp/test_message_client.py::test_message_client_reconnect",
 	"tests/pytests/functional/transport/zeromq/test_pub_server_channel.py::test_zeromq_filtering",  # Make pytest to hang on sle15sp1
 	"tests/pytests/functional/utils/pyinstaller/rthooks/test_salt_utils_vt_terminal.py::test_vt_terminal_environ_cleanup[LD_LIBRARY_PATH]",

--- a/skipped_tests.toml
+++ b/skipped_tests.toml
@@ -1,15 +1,15 @@
 [ignore]
 unit = [
-	"tests/pytests/unit/utils/test_x509.py",
+	"tests/pytests/unit/utils/test_x509.py",  # Failing with Salt Bundle
 	"tests/unit/modules/test_boto3_elasticsearch.py",
 	"tests/unit/modules/test_boto3_route53.py",
 	"tests/unit/modules/test_boto_route53.py",
-	"tests/unit/states/test_module.py",
+	"tests/unit/states/test_module.py",  # Failing with Salt Bundle
 	"tests/unit/utils/test_boto3mod.py",
 ]
 integration = [
-	"tests/pytests/integration/modules/test_x509_v2.py",
-	"tests/pytests/integration/states/test_x509_v2.py",
+	"tests/pytests/integration/modules/test_x509_v2.py",  # Failing with Salt Bundle
+	"tests/pytests/integration/states/test_x509_v2.py",  # Failing with Salt Bundle
 ]
 [skip]
 unit = [

--- a/skipped_tests.toml
+++ b/skipped_tests.toml
@@ -1,15 +1,11 @@
 [ignore]
 unit = [
-	"tests/pytests/unit/utils/test_x509.py",  # Failing with Salt Bundle
 	"tests/unit/modules/test_boto3_elasticsearch.py",
 	"tests/unit/modules/test_boto3_route53.py",
 	"tests/unit/modules/test_boto_route53.py",
-	"tests/unit/states/test_module.py",  # Failing with Salt Bundle
 	"tests/unit/utils/test_boto3mod.py",
 ]
 integration = [
-	"tests/pytests/integration/modules/test_x509_v2.py",  # Failing with Salt Bundle
-	"tests/pytests/integration/states/test_x509_v2.py",  # Failing with Salt Bundle
 ]
 [skip]
 unit = [

--- a/skipped_tests.toml
+++ b/skipped_tests.toml
@@ -1,9 +1,19 @@
 [ignore]
 unit = [
+	"tests/pytests/unit/utils/test_x509.py",
+	"tests/unit/modules/test_boto3_elasticsearch.py",
+	"tests/unit/modules/test_boto3_route53.py",
+	"tests/unit/modules/test_boto_route53.py",
+	"tests/unit/states/test_module.py",
+	"tests/unit/utils/test_boto3mod.py",
 	"tests/unit/modules/test_boto3_elasticsearch.py",
 	"tests/unit/modules/test_boto3_route53.py",
 	"tests/unit/modules/test_boto_route53.py",
 	"tests/unit/utils/test_boto3mod.py",
+]
+integration = [
+	"tests/pytests/integration/modules/test_x509_v2.py",
+	"tests/pytests/integration/states/test_x509_v2.py",
 ]
 [skip]
 unit = [
@@ -146,6 +156,7 @@ functional = [
 	"tests/pytests/functional/runners/test_winrepo.py::test_update_git_repos",
 	"tests/pytests/functional/states/test_pip_state.py::test_pip_installed_name_test_mode",
 	"tests/pytests/functional/states/test_pip_state.py::test_pip_installed_pkgs_test_mode",
+	"tests/pytests/functional/transport/ipc/test_pub_server_channel.py::test_publish_to_pubserv_ipc",
 	"tests/pytests/functional/transport/tcp/test_message_client.py::test_message_client_reconnect",
 	"tests/pytests/functional/utils/pyinstaller/rthooks/test_salt_utils_vt_terminal.py::test_vt_terminal_environ_cleanup[LD_LIBRARY_PATH]",
 	"tests/pytests/functional/utils/pyinstaller/rthooks/test_salt_utils_vt_terminal.py::test_vt_terminal_environ_cleanup_original[LD_LIBRARY_PATH]",

--- a/skipped_tests.toml
+++ b/skipped_tests.toml
@@ -55,6 +55,9 @@ unit = [
 	"tests/pytests/unit/modules/test_transactional_update.py::test_call_success_parameters",
 	"tests/pytests/unit/modules/test_transactional_update.py::test_call_success_reboot",
 	"tests/pytests/unit/states/file/test_tidied.py::test_tidied_age_size_args_AND_operator_age_not_size",
+	"tests/unit/modules/test_zcbuildout.py::BuildoutOnlineTestCase::test_buildout",  # Unmaintained test - skipped upstream
+	"tests/unit/modules/test_zcbuildout.py::BuildoutOnlineTestCase::test_run_buildout",  # Unmaintained test - skipped upstream
+	"tests/unit/states/test_zcbuildout.py::BuildoutTestCase::test_installed",  # Unmaintained test - skipped upstream
 	"tests/pytests/unit/states/file/test_tidied.py::test_tidied_age_size_args_AND_operator_size_not_age",
 	"tests/pytests/unit/states/test_pkgrepo.py::test_migrated_wrong_method",
 	"tests/pytests/unit/utils/test_gitfs.py::test_full_id_pygit2",

--- a/skipped_tests.toml
+++ b/skipped_tests.toml
@@ -121,10 +121,11 @@ unit = [
 	"tests/unit/utils/test_templates.py::RenderTestCase::test_render_mako_variable",
 ]
 integration = [
+	"tests/integration/loader/test_ext_modules.py",  # Make pytest to stuck in sle15sp1 classic pkg
 	"tests/integration/modules/test_cmdmod.py::CMDModuleTest::test_which_bin",
 	"tests/pytests/integration/master/test_clear_funcs.py::test_clearfuncs_config",
-	"tests/pytests/integration/master/test_clear_funcs.py::test_fileroots_write",
 	"tests/pytests/integration/master/test_clear_funcs.py::test_fileroots_read",
+	"tests/pytests/integration/master/test_clear_funcs.py::test_fileroots_write",
 	"tests/pytests/integration/netapi/rest_tornado/test_minions_api_handler.py::test_get_no_mid",
 	"tests/pytests/integration/netapi/rest_tornado/test_root_handler.py::test_simple_local_post",
 	"tests/pytests/integration/netapi/rest_tornado/test_root_handler.py::test_simple_local_post_only_dictionary_request",

--- a/skipped_tests.toml
+++ b/skipped_tests.toml
@@ -136,6 +136,7 @@ integration = [
 	"tests/pytests/integration/runners/state/orchestrate/test_events.py::test_jid_in_ret_event",
 	"tests/pytests/integration/runners/state/orchestrate/test_events.py::test_orchestration_with_pillar_dot_items",
 	"tests/pytests/integration/runners/state/orchestrate/test_events.py::test_parallel_orchestrations",
+	"tests/integration/ssh/test_state.py::SSHStateTest::test_state_running",  # This test makes no sense with new locking mechanism for Salt SSH
 ]
 functional = [
 	"tests/pytests/functional/channel/test_server.py::test_pub_server_channel[transport(zeromq)]",

--- a/skipped_tests.toml
+++ b/skipped_tests.toml
@@ -82,11 +82,17 @@ unit = [
 	"tests/unit/states/test_boto_apigateway.py::BotoApiGatewayTestCase::test_absent_when_stage_is_valid_and_only_one_stage_is_associated_to_deployment",
 	"tests/unit/states/test_boto_apigateway.py::BotoApiGatewayTestCase::test_absent_when_stage_is_valid_and_two_stages_are_associated_to_deployment",
 	"tests/unit/states/test_boto_apigateway.py::BotoApiGatewayTestCase::test_present_when_stage_associating_to_new_deployment_errored_on_api_creation",
+	"tests/unit/states/test_boto_apigateway.py::BotoApiGatewayTestCase::test_present_when_stage_associating_to_new_deployment_errored_on_lambda_function_lookup",  # missing boto libraries
 	"tests/unit/states/test_boto_apigateway.py::BotoApiGatewayTestCase::test_present_when_stage_associating_to_new_deployment_errored_on_model_creation",
+	"tests/unit/states/test_boto_apigateway.py::BotoApiGatewayTestCase::test_present_when_stage_associating_to_new_deployment_errored_on_put_integration",  # missing boto libraries
+	"tests/unit/states/test_boto_apigateway.py::BotoApiGatewayTestCase::test_present_when_stage_associating_to_new_deployment_errored_on_put_integration_response",  # missing boto libraries
+	"tests/unit/states/test_boto_apigateway.py::BotoApiGatewayTestCase::test_present_when_stage_associating_to_new_deployment_errored_on_put_method",  # missing boto libraries
+	"tests/unit/states/test_boto_apigateway.py::BotoApiGatewayTestCase::test_present_when_stage_associating_to_new_deployment_errored_on_put_method_response",  # missing boto libraries
 	"tests/unit/states/test_boto_apigateway.py::BotoApiGatewayTestCase::test_present_when_stage_associating_to_new_deployment_errored_on_resource_creation",
 	"tests/unit/states/test_boto_apigateway.py::BotoApiGatewayTestCase::test_present_when_stage_exists_and_is_to_associate_to_existing_deployment",
 	"tests/unit/states/test_boto_apigateway.py::BotoApiGatewayTestCase::test_present_when_stage_is_already_at_desired_deployment",
 	"tests/unit/states/test_boto_apigateway.py::BotoApiGatewayTestCase::test_present_when_stage_is_already_at_desired_deployment_and_needs_stage_variables_update",
+	"tests/unit/states/test_boto_apigateway.py::BotoApiGatewayTestCase::test_present_when_stage_is_to_associate_to_new_deployment",  # missing boto libraries
 	"tests/unit/states/test_boto_apigateway.py::BotoApiGatewayTestCase::test_present_when_swagger_file_is_invalid",
 	"tests/unit/states/test_boto_cognitoidentity.py::BotoCognitoIdentityTestCase::test_absent_when_a_single_pool_exists",
 	"tests/unit/states/test_boto_cognitoidentity.py::BotoCognitoIdentityTestCase::test_absent_when_erroring_on_delete_identity_pool",
@@ -97,8 +103,11 @@ unit = [
 	"tests/unit/states/test_boto_cognitoidentity.py::BotoCognitoIdentityTestCase::test_present_when_failing_to_create_a_new_identity_pool",
 	"tests/unit/states/test_boto_cognitoidentity.py::BotoCognitoIdentityTestCase::test_present_when_failing_to_describe_identity_pools",
 	"tests/unit/states/test_boto_cognitoidentity.py::BotoCognitoIdentityTestCase::test_present_when_failing_to_get_identity_pool_roles",
+	"tests/unit/states/test_boto_cognitoidentity.py::BotoCognitoIdentityTestCase::test_present_when_failing_to_set_identity_pool_roles",  # missing boto libraries
 	"tests/unit/states/test_boto_cognitoidentity.py::BotoCognitoIdentityTestCase::test_present_when_failing_to_update_an_existing_identity_pool",
 	"tests/unit/states/test_boto_cognitoidentity.py::BotoCognitoIdentityTestCase::test_present_when_multiple_pools_with_same_name_exist",
+	"tests/unit/states/test_boto_cognitoidentity.py::BotoCognitoIdentityTestCase::test_present_when_pool_name_does_not_exist",  # missing boto libraries
+	"tests/unit/states/test_boto_cognitoidentity.py::BotoCognitoIdentityTestCase::test_present_when_pool_name_exists",  # missing boto libraries
 	"tests/unit/test_config.py::APIConfigTestCase::test_api_config_log_file_values",
 	"tests/unit/test_config.py::APIConfigTestCase::test_api_config_prepend_root_dirs_return",
 	"tests/unit/test_config.py::ConfigTestCase::test_load_minion_config_from_environ_var",

--- a/skipped_tests.toml
+++ b/skipped_tests.toml
@@ -157,8 +157,10 @@ functional = [
 	"tests/pytests/functional/runners/test_winrepo.py::test_update_git_repos",
 	"tests/pytests/functional/states/test_pip_state.py::test_pip_installed_name_test_mode",
 	"tests/pytests/functional/states/test_pip_state.py::test_pip_installed_pkgs_test_mode",
+	"tests/pytests/functional/transport/ipc/test_pub_server_channel.py::test_issue_36469_tcp",  # Make pytest to hang on sle15sp1
 	"tests/pytests/functional/transport/ipc/test_pub_server_channel.py::test_publish_to_pubserv_ipc",
 	"tests/pytests/functional/transport/tcp/test_message_client.py::test_message_client_reconnect",
+	"tests/pytests/functional/transport/zeromq/test_pub_server_channel.py::test_zeromq_filtering",  # Make pytest to hang on sle15sp1
 	"tests/pytests/functional/utils/pyinstaller/rthooks/test_salt_utils_vt_terminal.py::test_vt_terminal_environ_cleanup[LD_LIBRARY_PATH]",
 	"tests/pytests/functional/utils/pyinstaller/rthooks/test_salt_utils_vt_terminal.py::test_vt_terminal_environ_cleanup_original[LD_LIBRARY_PATH]",
 	"tests/pytests/functional/utils/pyinstaller/rthooks/test_salt_utils_vt_terminal.py::test_vt_terminal_environ_cleanup_original_passed_directly[LD_LIBRARY_PATH]",


### PR DESCRIPTION
Based on the initial Salt Shaker runs, these are some tests we need to ignore to prevent errors and also skip to avoid hanging executions.