### PR TITLE
Ignore test_adding_repo_file_arch test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# IDE files
+/.vscode
+/.settings
+/.project
+/.pydevproject
+/.idea
+/.ropeproject
+*_flymake.py
+/*.iml
+*.sublime-project
+*.sublime-workspace
+*.un~

--- a/skipped_tests.toml
+++ b/skipped_tests.toml
@@ -163,6 +163,7 @@ functional = [
 	"tests/pytests/functional/utils/yamllint/test_yamllint.py::test_has_yamllint",
 	"tests/pytests/functional/utils/yamllint/test_yamllint.py::test_input_bytes",
 	"tests/pytests/functional/utils/yamllint/test_yamllint.py::test_version",
+	"tests/pytests/functional/states/pkgrepo/test_debian.py::test_adding_repo_file_arch", # Seems to cause "Socket exception: Connection timed out" on Debian 11
 ]
 scenarios = [
 	"tests/pytests/scenarios/blackout/test_minion_blackout.py::test_blackout",


### PR DESCRIPTION
In this PR, we're disabling the `test_adding_repo_file_arch` test, which causes Debian 11 failures in the Salt Shaker debian 11 pipelines.

This test seems to cause the `ERROR - Socket exception: Connection timed out (110)` error, which also later causes for Jenkins not being able to retrieve the test results from the Salt Shaker VM.

Additionally, I'm adding a gitignore file for editor-specific files as a QoL improvement.