### PR TITLE
Ignore deltaproxy integration tests

### DIFF
--- a/skipped_tests.toml
+++ b/skipped_tests.toml
@@ -6,6 +6,8 @@ unit = [
 	"tests/unit/utils/test_boto3mod.py",
 ]
 integration = [
+	"tests/pytests/integration/cli/test_salt_deltaproxy.py",
+	"tests/pytests/integration/proxy/test_deltaproxy.py",
 ]
 [skip]
 unit = [


### PR DESCRIPTION
There are integration tests related to deltaproxy which started failing or causing errors after merging https://github.com/openSUSE/salt/pull/755

We are not using this functionality in the product and it could be that the only tests are affected here as with checking debug output there are some weird injections to the `opts` dumping all `opts` content inside `master` key causing the following:
```
DEBUG:salt.minion:[SaltProxyMinion(id='proxy-minion-1EXR5n')] Minion of '{'interface': '127.0.0.1', 'publish_port': 40595, 'zmq_backlog': 1000, 'pub_hwm': 1000, 'auth_mode': 1, 'user': 'root', 'worker_threads': 3, 'sock_dir': '/tmp/stsuite/master-jetg6p/run/master', 'sock_pool_size': 1, 'ret_port': 41701, 'timeout': 12, 'keep_jobs': 24, 'keep_jobs_seconds': 86400, 'archive_jobs': False, 'root_dir': '/tmp/stsuite/master-jetg6p', 'pki_dir': '/tmp/stsuite/master-jetg6p/pki', 'key_cache': '', 'cachedir': '/tmp/stsuite/master-jetg6p/cache', 'file_roots': {'base': ['/tmp/stsuite/master-jetg6p/state-tree/base', '/tmp/stsuite/integration-files/state-tree/base', '/usr/lib/python3.11/site-packages/salt-testsuite/tests/integration/files/file/base'], 'prod': ['/tmp/stsuite/master-jetg6p/state-tree/prod', '/tmp/stsuite/integration-files/state-tree/prod', '/usr/lib/python3.11/site-packages/salt-testsuite/tests/integration/files/file/prod']}, 'master_roots': {'base': ['/srv/salt-master']}, 'pillar_roots': {'base': ['/tmp/stsuite/master-jetg6p/pillar-tree/base', '/tmp/stsuite/integration-files/pillar-tree/base', '/usr/lib/python3.11/site-packages/salt-testsuite/tests/integration/files/pillar/base'], 'prod': ['/tmp/stsuite/master-jetg6p/pillar-tree/prod', '/tmp/stsuite/integration-files/pillar-tree/prod']}, 'on_demand_ext_pillar':
...
```

The same is present there with with rolling back https://github.com/openSUSE/salt/pull/755, so most probably the tests themselves are problematic.